### PR TITLE
Timeseries speedup

### DIFF
--- a/src/data.convert.js
+++ b/src/data.convert.js
@@ -155,11 +155,10 @@ c3_chart_internal_fn.convertDataToTargets = function (data, appendXs) {
         if ($$.isCustomX() || $$.isTimeSeries()) {
             // if included in input data
             if (xs.indexOf(xKey) >= 0) {
-                $$.data.xs[id] = (appendXs && $$.data.xs[id] ? $$.data.xs[id] : []).concat(
-                    data.map(function (d) { return d[xKey]; })
-                        .filter(isValue)
-                        .map(function (rawX, i) { return $$.generateTargetX(rawX, id, i); })
-                );
+                var existing = (appendXs && $$.data.xs[id] ? $$.data.xs[id] : []);
+                var appended = data.filter(function (d) { return xKey in d; })
+                    .map(function (d, i) { return $$.generateTargetX(d[xKey], id, i); });
+                $$.data.xs[id] = existing.concat(appended);
             }
             // if not included in input data, find from preloaded data of other id's x
             else if (config.data_x) {

--- a/src/data.convert.js
+++ b/src/data.convert.js
@@ -137,10 +137,16 @@ c3_chart_internal_fn.convertColumnsToData = (columns) => {
 };
 
 c3_chart_internal_fn.convertDataToTargets = function (data, appendXs) {
-    var $$ = this, config = $$.config,
-        ids = $$.d3.keys(data[0]).filter($$.isNotX, $$),
-        xs = $$.d3.keys(data[0]).filter($$.isX, $$),
-        targets;
+    var $$ = this, config = $$.config, targets;
+
+    var d3keys = $$.d3.keys(data[0]),
+        xsRaw = {}; // use xsRaw as set
+
+    if (config.data_x) xsRaw[config.data_x] = true;
+    if (config.data_xs) Object.values(config.data_xs).forEach(function (v) { xsRaw[v] = true; });
+
+    var xs = d3keys.filter(function (v) { return v in xsRaw; });
+    var ids = d3keys.filter(function (v) { return !(v in xsRaw); });
 
     // save x for update data by load when custom x and c3.x API
     ids.forEach(function (id) {

--- a/src/data.convert.js
+++ b/src/data.convert.js
@@ -181,10 +181,14 @@ c3_chart_internal_fn.convertDataToTargets = function (data, appendXs) {
     targets = ids.map(function (id, index) {
         var convertedId = config.data_idConverter(id);
         var xKey = $$.getXKey(id);
+
+        var maxIndex = $$.data.xs[id].length;
+        var pruned = data.slice(0, maxIndex).filter(function (d) { return isDefined(d[id]); });
+
         return {
             id: convertedId,
             id_org: id,
-            values: data.map(function (d, i) {
+            values: pruned.map(function (d, i) {
                 var rawX = d[xKey],
                     value = d[id] !== null && !isNaN(d[id]) ? +d[id] : null, x;
                 // use x as categories if custom x and categorized
@@ -200,12 +204,8 @@ c3_chart_internal_fn.convertDataToTargets = function (data, appendXs) {
                 } else {
                     x  = $$.generateTargetX(rawX, id, i);
                 }
-                // mark as x = undefined if value is undefined and filter to remove after mapped
-                if (isUndefined(d[id]) || $$.data.xs[id].length <= i) {
-                    x = undefined;
-                }
                 return {x: x, value: value, id: convertedId};
-            }).filter(function (v) { return isDefined(v.x); })
+            })
         };
     });
 

--- a/src/data.convert.js
+++ b/src/data.convert.js
@@ -1,5 +1,5 @@
 import { c3_chart_internal_fn } from './core';
-import { isValue, isUndefined, isDefined, notEmpty } from './util';
+import { isUndefined, isDefined, notEmpty } from './util';
 
 c3_chart_internal_fn.convertUrlToData = function (url, mimeType, headers, keys, done) {
     var $$ = this, type = mimeType ? mimeType : 'csv';
@@ -139,11 +139,16 @@ c3_chart_internal_fn.convertColumnsToData = (columns) => {
 c3_chart_internal_fn.convertDataToTargets = function (data, appendXs) {
     var $$ = this, config = $$.config, targets;
 
+    // extract x and y values
     var d3keys = $$.d3.keys(data[0]),
         xsRaw = {}; // use xsRaw as set
 
-    if (config.data_x) xsRaw[config.data_x] = true;
-    if (config.data_xs) Object.values(config.data_xs).forEach(function (v) { xsRaw[v] = true; });
+    if (config.data_x) {
+        xsRaw[config.data_x] = true;
+    }
+    if (config.data_xs) {
+        Object.values(config.data_xs).forEach(function (v) { xsRaw[v] = true; });
+    }
 
     var xs = d3keys.filter(function (v) { return v in xsRaw; });
     var ids = d3keys.filter(function (v) { return !(v in xsRaw); });

--- a/src/util.js
+++ b/src/util.js
@@ -37,11 +37,7 @@ export var getOption = function (options, key, defaultValue) {
     return isDefined(options[key]) ? options[key] : defaultValue;
 };
 export var hasValue = function (dict, value) {
-    var found = false;
-    Object.keys(dict).forEach(function (key) {
-        if (dict[key] === value) { found = true; }
-    });
-    return found;
+    return (Object.values(dict).indexOf(value) > -1);
 };
 export var sanitise = function (str) {
     return typeof str === 'string' ? str.replace(/</g, '&lt;').replace(/>/g, '&gt;') : str;


### PR DESCRIPTION
This PR focuses on performance improvements for "convertColumnsToData" without affecting functionality.

The current implementation has a number of O(n^2) and O(m*n) passages that can be replaced with O(n) counterparts. Also, there are several opportunities where we can apply filter() before map() and avoid creating unnecessary instances (and garbage collecting them later).